### PR TITLE
Feature/buienradar resilience

### DIFF
--- a/tests/test_datasources_resilience.py
+++ b/tests/test_datasources_resilience.py
@@ -1,8 +1,9 @@
 import asyncio
 import unittest
-from unittest.mock import patch, AsyncMock, MagicMock, call
+from unittest.mock import patch, AsyncMock, MagicMock, call, Mock
 
 import httpx # Required for httpx.RequestError
+import pytest
 
 # Assuming BuienRadarDataSource and HTTP_OK are in weathervane.datasources
 # Adjust the import path if your project structure is different.
@@ -24,36 +25,52 @@ class TestBuienRadarDataSourceResilience(unittest.IsolatedAsyncioTestCase):
         pass
 
     @patch('asyncio.sleep', new_callable=AsyncMock)
-    @patch('httpx.AsyncClient', new_callable=AsyncMock) # Mocks the AsyncClient class
+    @patch('httpx.AsyncClient')  # Remove new_callable=AsyncMock
     async def test_get_weather_success_first_try(self, mock_async_client_class, mock_sleep, mock_logger_class_level):
-        mock_client_instance = mock_async_client_class.return_value.__aenter__.return_value
-        mock_response = AsyncMock()
+        # Set up async context manager
+        mock_client_instance = AsyncMock()
+        mock_async_client_class.return_value.__aenter__ = AsyncMock(return_value=mock_client_instance)
+        mock_async_client_class.return_value.__aexit__ = AsyncMock(return_value=None)
+
+        mock_response = Mock()
         mock_response.status_code = HTTP_OK
-        mock_response.text = '{"actual":{"actual": "data"}}'
         mock_response.elapsed = MagicMock()
-        mock_response.elapsed.total_seconds.return_value = 0.1 # 100 ms
+        mock_response.elapsed.total_seconds.return_value = 0.1  # 100 ms
+
+        # Mock the json() method to return actual dict
+        expected_data = {"actual": {"actual": "data"}}
+        mock_response.json.return_value = expected_data
+
         mock_client_instance.get.return_value = mock_response
 
-        data_source = BuienRadarDataSource(queue=None, stations=[], bits=[]) 
-        
+        data_source = BuienRadarDataSource(queue=None, stations=[], bits=[])
+
         result = await data_source._BuienRadarDataSource__get_weather()
 
-        self.assertEqual(result, '{"actual":{"actual": "data"}}')
-        mock_client_instance.get.assert_called_once_with("https.data.buienradar.nl/2.0/feed/json", timeout=5)
+        # Your code returns r.json(), which is a dict, not a string
+        self.assertEqual(result, expected_data)
+        mock_client_instance.get.assert_called_once_with("https://data.buienradar.nl/2.0/feed/json", timeout=5)
         mock_sleep.assert_not_called()
         mock_logger_class_level.info.assert_any_call("Weather data retrieved in 100 ms on attempt 1")
 
     @patch('asyncio.sleep', new_callable=AsyncMock)
-    @patch('httpx.AsyncClient', new_callable=AsyncMock)
-    async def test_get_weather_success_after_retries_req_error(self, mock_async_client_class, mock_sleep, mock_logger_class_level):
-        mock_client_instance = mock_async_client_class.return_value.__aenter__.return_value
-        
-        mock_failure_exception = httpx.RequestError("Simulated network error", request=MagicMock()) # Add request object
-        mock_successful_response = AsyncMock()
+    @patch('httpx.AsyncClient')  # Remove new_callable=AsyncMock
+    async def test_get_weather_success_after_retries_req_error(self, mock_async_client_class, mock_sleep,
+                                                               mock_logger_class_level):
+        # Set up async context manager
+        mock_client_instance = AsyncMock()
+        mock_async_client_class.return_value.__aenter__ = AsyncMock(return_value=mock_client_instance)
+        mock_async_client_class.return_value.__aexit__ = AsyncMock(return_value=None)
+
+        mock_failure_exception = httpx.RequestError("Simulated network error", request=MagicMock())
+
+        # Create successful response mock
+        mock_successful_response = Mock()
         mock_successful_response.status_code = HTTP_OK
-        mock_successful_response.text = '{"success":true}'
         mock_successful_response.elapsed = MagicMock()
-        mock_successful_response.elapsed.total_seconds.return_value = 0.1 # 100 ms
+        mock_successful_response.elapsed.total_seconds.return_value = 0.1
+        expected_data = {"success": True}
+        mock_successful_response.json.return_value = expected_data
 
         mock_client_instance.get.side_effect = [
             mock_failure_exception,
@@ -64,100 +81,114 @@ class TestBuienRadarDataSourceResilience(unittest.IsolatedAsyncioTestCase):
         data_source = BuienRadarDataSource(queue=None, stations=[], bits=[])
         result = await data_source._BuienRadarDataSource__get_weather()
 
-        self.assertEqual(result, '{"success":true}')
+        self.assertEqual(expected_data, result)
         self.assertEqual(mock_client_instance.get.call_count, 3)
         mock_sleep.assert_has_calls([call(10), call(10)])
         self.assertEqual(mock_sleep.call_count, 2)
-        
+
         # Check log calls
-        mock_logger_class_level.warning.assert_any_call("Attempt 1/4: RequestError connecting to Buienradar: Simulated network error")
-        mock_logger_class_level.warning.assert_any_call("Attempt 2/4: RequestError connecting to Buienradar: Simulated network error")
+        mock_logger_class_level.warning.assert_any_call(
+            "Attempt 1/4: RequestError connecting to Buienradar: Simulated network error")
+        mock_logger_class_level.warning.assert_any_call(
+            "Attempt 2/4: RequestError connecting to Buienradar: Simulated network error")
         mock_logger_class_level.info.assert_any_call("Weather data retrieved in 100 ms on attempt 3")
 
     @patch('asyncio.sleep', new_callable=AsyncMock)
-    @patch('httpx.AsyncClient', new_callable=AsyncMock)
-    async def test_get_weather_success_after_retries_status_code(self, mock_async_client_class, mock_sleep, mock_logger_class_level):
-        mock_client_instance = mock_async_client_class.return_value.__aenter__.return_value
+    @patch('httpx.AsyncClient')  # Remove new_callable=AsyncMock
+    async def test_get_weather_success_after_retries_status_code(self, mock_async_client_class, mock_sleep,
+                                                                 mock_logger_class_level):
+        # Set up async context manager
+        mock_client_instance = AsyncMock()
+        mock_async_client_class.return_value.__aenter__ = AsyncMock(return_value=mock_client_instance)
+        mock_async_client_class.return_value.__aexit__ = AsyncMock(return_value=None)
 
-        mock_failure_response = AsyncMock()
+        mock_failure_response = Mock()
         mock_failure_response.status_code = 500
-        mock_failure_response.text = '{"error":"server_error"}'
         mock_failure_response.elapsed = MagicMock()
-        mock_failure_response.elapsed.total_seconds.return_value = 0.05 # 50ms
+        mock_failure_response.elapsed.total_seconds.return_value = 0.05  # 50ms
 
-        mock_successful_response = AsyncMock()
+        mock_successful_response = Mock()
         mock_successful_response.status_code = HTTP_OK
-        mock_successful_response.text = '{"success":true}'
         mock_successful_response.elapsed = MagicMock()
-        mock_successful_response.elapsed.total_seconds.return_value = 0.1 # 100ms
-        
+        mock_successful_response.elapsed.total_seconds.return_value = 0.1  # 100ms
+        # Mock the json() method to return actual dict
+        expected_data = {"success": True}
+        mock_successful_response.json.return_value = expected_data
+
         mock_client_instance.get.side_effect = [
-            mock_failure_response, 
-            mock_failure_response, 
+            mock_failure_response,
+            mock_failure_response,
             mock_successful_response
         ]
 
         data_source = BuienRadarDataSource(queue=None, stations=[], bits=[])
         result = await data_source._BuienRadarDataSource__get_weather()
 
-        self.assertEqual(result, '{"success":true}')
+        # Your code returns r.json(), which is a dict, not a string
+        self.assertEqual(result, expected_data)
         self.assertEqual(mock_client_instance.get.call_count, 3)
         mock_sleep.assert_has_calls([call(10), call(10)])
         self.assertEqual(mock_sleep.call_count, 2)
 
-        mock_logger_class_level.warning.assert_any_call("Attempt 1/4: Got response in 50 ms, but unexpected status code 500")
-        mock_logger_class_level.warning.assert_any_call("Attempt 2/4: Got response in 50 ms, but unexpected status code 500")
+        mock_logger_class_level.warning.assert_any_call(
+            "Attempt 1/4: Got response in 50 ms, but unexpected status code 500")
+        mock_logger_class_level.warning.assert_any_call(
+            "Attempt 2/4: Got response in 50 ms, but unexpected status code 500")
         mock_logger_class_level.info.assert_any_call("Weather data retrieved in 100 ms on attempt 3")
 
     @patch('asyncio.sleep', new_callable=AsyncMock)
-    @patch('httpx.AsyncClient', new_callable=AsyncMock)
-    async def test_get_weather_failure_all_retries_request_error(self, mock_async_client_class, mock_sleep, mock_logger_class_level):
-        mock_client_instance = mock_async_client_class.return_value.__aenter__.return_value
-        mock_failure_exception = httpx.RequestError("Simulated persistent network error", request=MagicMock()) # Add request
+    @patch('httpx.AsyncClient')  # Remove new_callable=AsyncMock
+    async def test_get_weather_failure_all_retries_request_error(self, mock_async_client_class, mock_sleep,
+                                                                 mock_logger_class_level):
+        # Create a proper async context manager mock
+        mock_client_instance = AsyncMock()
+        mock_async_client_class.return_value.__aenter__ = AsyncMock(return_value=mock_client_instance)
+        mock_async_client_class.return_value.__aexit__ = AsyncMock(return_value=None)
+
+        mock_failure_exception = httpx.RequestError("Simulated persistent network error", request=MagicMock())
         # max_retries = 3, so 4 attempts total
-        mock_client_instance.get.side_effect = [mock_failure_exception] * 4 
+        mock_client_instance.get.side_effect = [mock_failure_exception] * 4
 
         data_source = BuienRadarDataSource(queue=None, stations=[], bits=[])
-        
-        with self.assertRaises(httpx.RequestError):
+
+        with pytest.raises(httpx.RequestError):
             await data_source._BuienRadarDataSource__get_weather()
 
         self.assertEqual(mock_client_instance.get.call_count, 4)
-        self.assertEqual(mock_sleep.call_count, 3) # Sleeps between 4 attempts
+        self.assertEqual(mock_sleep.call_count, 3)  # Sleeps between 4 attempts
         mock_sleep.assert_has_calls([call(10)] * 3)
         mock_logger_class_level.error.assert_any_call("All 4 attempts to connect to Buienradar failed.")
         # Check that specific warnings for each attempt were logged
-        for i in range(1, 5): # Attempts 1 through 4
-            mock_logger_class_level.warning.assert_any_call(f"Attempt {i}/4: RequestError connecting to Buienradar: Simulated persistent network error")
-
+        for i in range(1, 5):  # Attempts 1 through 4
+            mock_logger_class_level.warning.assert_any_call(
+                f"Attempt {i}/4: RequestError connecting to Buienradar: Simulated persistent network error")
 
     @patch('asyncio.sleep', new_callable=AsyncMock)
-    @patch('httpx.AsyncClient', new_callable=AsyncMock)
-    async def test_get_weather_failure_all_retries_status_code(self, mock_async_client_class, mock_sleep, mock_logger_class_level):
-        mock_client_instance = mock_async_client_class.return_value.__aenter__.return_value
-        
+    @patch('httpx.AsyncClient')  # Remove new_callable=AsyncMock
+    async def test_get_weather_failure_all_retries_status_code(self, mock_async_client_class, mock_sleep,
+                                                               mock_logger_class_level):
+        mock_client_instance = AsyncMock()
+        mock_async_client_class.return_value.__aenter__ = AsyncMock(return_value=mock_client_instance)
+        mock_async_client_class.return_value.__aexit__ = AsyncMock(return_value=None)
+
         mock_failure_response = AsyncMock()
-        mock_failure_response.status_code = 503 # Service Unavailable
+        mock_failure_response.status_code = 503
         mock_failure_response.text = '{"error":"unavailable"}'
         mock_failure_response.elapsed = MagicMock()
         mock_failure_response.elapsed.total_seconds.return_value = 0.05
 
-        # max_retries = 3, so 4 attempts total
-        mock_client_instance.get.side_effect = [mock_failure_response] * 4
+        mock_client_instance.get.return_value = mock_failure_response  # Use return_value, not side_effect
 
         data_source = BuienRadarDataSource(queue=None, stations=[], bits=[])
-        
-        with self.assertRaises(ConnectionError) as cm:
+
+        with pytest.raises(ConnectionError) as cm:
             await data_source._BuienRadarDataSource__get_weather()
-        
-        self.assertEqual(str(cm.exception), "Buienradar: 503")
+
+        self.assertEqual(str(cm.value), "Buienradar: 503")  # Use cm.value, not cm.exception
         self.assertEqual(mock_client_instance.get.call_count, 4)
         self.assertEqual(mock_sleep.call_count, 3)
         mock_sleep.assert_has_calls([call(10)] * 3)
         mock_logger_class_level.error.assert_any_call("All 4 attempts to connect to Buienradar failed.")
-        # Check that specific warnings for each attempt were logged
-        for i in range(1, 5): # Attempts 1 through 4
-            mock_logger_class_level.warning.assert_any_call(f"Attempt {i}/4: Got response in 50 ms, but unexpected status code 503")
-
-# if __name__ == '__main__':
-#    unittest.main()
+        for i in range(1, 5):
+            mock_logger_class_level.warning.assert_any_call(
+                f"Attempt {i}/4: Got response in 50 ms, but unexpected status code 503")

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,3 +1,4 @@
+import json
 import os
 
 import pytest
@@ -31,6 +32,7 @@ def load_test_data(stations):
     file_path = os.path.join(os.getcwd(), "tests", "buienradar.json")
     with open(file_path, "r", encoding="UTF-8") as f:
         data = f.read()
+        data = json.loads(data)
         config = {
             "stations": stations,
             "bits": bits,

--- a/weathervane/datasources.py
+++ b/weathervane/datasources.py
@@ -1,6 +1,8 @@
 import logging
-
-import httpx
+import asyncio
+import httpx # Ensure this is imported for RequestError
+import subprocess
+import time
 
 from weathervane.parser import BuienradarParser
 
@@ -33,27 +35,157 @@ class BuienRadarDataSource:
 
     @staticmethod
     async def __get_weather():
-        async with httpx.AsyncClient() as client:
-            r = await client.get("https://data.buienradar.nl/2.0/feed/json", timeout=5)
+        max_retries = 3
+        retry_delay_seconds = 10
+        last_exception = None
 
-        if r.status_code == HTTP_OK:
-            logger.info(f"Weather data retrieved in {r.elapsed} ms")
-            return r.text
-        else:
-            logger.warning(f"Got response in {r.elapsed} ms, but unexpected status code {r.status_code}")
-            raise ConnectionError(f"Buienradar: {r.status_code}")
+        for attempt in range(max_retries + 1):
+            try:
+                async with httpx.AsyncClient() as client:
+                    r = await client.get("https://data.buienradar.nl/2.0/feed/json", timeout=5)
+                
+                if r.status_code == HTTP_OK:
+                    logger.info(f"Weather data retrieved in {r.elapsed.total_seconds() * 1000:.0f} ms on attempt {attempt + 1}") # Adjusted logging for timedelta
+                    return r.text
+                else:
+                    logger.warning(f"Attempt {attempt + 1}/{max_retries + 1}: Got response in {r.elapsed.total_seconds() * 1000:.0f} ms, but unexpected status code {r.status_code}") # Adjusted logging for timedelta
+                    last_exception = ConnectionError(f"Buienradar: {r.status_code}")
+                    # This ConnectionError will be caught by the broader except block below if it's the last attempt or just be part of the loop
+                    # To ensure it's caught and processed by the retry logic, we raise it here.
+                    raise last_exception
+
+            except httpx.RequestError as e:
+                logger.warning(f"Attempt {attempt + 1}/{max_retries + 1}: RequestError connecting to Buienradar: {e}")
+                last_exception = e
+            except ConnectionError as e: # Catching the specific ConnectionError from status_code check
+                # The warning for non-OK status is already logged above.
+                # If we want to avoid re-logging or make it less verbose:
+                # logger.debug(f"Attempt {attempt + 1}/{max_retries + 1}: ConnectionError captured: {e}")
+                last_exception = e # Ensure last_exception is updated
+
+            if attempt < max_retries:
+                logger.info(f"Waiting {retry_delay_seconds} seconds before retrying...")
+                await asyncio.sleep(retry_delay_seconds)
+            elif last_exception: # If it's the last attempt and an exception occurred
+                logger.error(f"All {max_retries + 1} attempts to connect to Buienradar failed.")
+                raise last_exception
+        
+        # Fallback if loop finishes unexpectedly (should ideally be covered by raise last_exception)
+        # This part might be unreachable if last_exception is always raised on failure,
+        # but it's a safeguard as per the provided example.
+        logger.error("Exited retry loop for Buienradar without success or explicit error (should not happen).")
+        raise ConnectionError("Failed to retrieve data from Buienradar after multiple attempts.")
+
+    @staticmethod
+    def _reboot_system():
+        logger.info("Attempting system reboot using 'sudo reboot'...")
+        command = ["sudo", "reboot"]
+        try:
+            # Using Popen for reboot as it's a non-returning command usually.
+            subprocess.Popen(command)
+            logger.info("Reboot command issued. The system should now restart.")
+            # If Popen succeeds, script may end before this is reached or continue briefly.
+            # Return True to indicate the command was dispatched without Popen throwing an error.
+            return True
+        except FileNotFoundError:
+            logger.error("Reboot command failed: `sudo` or `reboot` not found. Ensure these utilities are installed and in PATH.")
+            return False # Return False indicating command couldn't be dispatched
+        except Exception as e:
+            logger.error(f"An unexpected error occurred while trying to issue reboot command: {e}")
+            return False # Return False indicating command couldn't be dispatched
+
+    @staticmethod
+    def _reset_wifi_connection():
+        logger.info("Attempting WiFi reset using 'sudo ifdown wlan0 && sudo ifup wlan0'...")
+        cmd_string = "sudo ifdown wlan0 && sudo ifup wlan0"
+
+        try:
+            # Using shell=True for the compound command.
+            result = subprocess.run(cmd_string, shell=True, capture_output=True, text=True, check=False, timeout=60) 
+            if result.returncode == 0:
+                logger.info("WiFi reset command executed successfully.")
+                logger.info("Waiting 10 seconds for network to re-establish...")
+                time.sleep(10) 
+                return True
+            else:
+                logger.error(f"WiFi reset command failed with return code {result.returncode}.")
+                if result.stdout:
+                    logger.error(f"STDOUT: {result.stdout.strip()}")
+                if result.stderr:
+                    logger.error(f"STDERR: {result.stderr.strip()}")
+                return False
+        except FileNotFoundError:
+            logger.error("WiFi reset command failed: `sudo`, `ifdown`, or `ifup` not found. Ensure these utilities are installed and in PATH.")
+            return False
+        except subprocess.TimeoutExpired:
+            logger.error("WiFi reset command timed out after 60 seconds.")
+            return False
+        except Exception as e:
+            logger.error(f"An unexpected error occurred during WiFi reset: {e}")
+            return False
 
     async def fetch_weather_data(self):
-        data = await self.__get_weather()
+        data = None
+        try:
+            data = await self.__get_weather()
+        except (httpx.RequestError, ConnectionError) as e:
+            logger.warning(f"Initial attempts to fetch weather data failed: {e}. Attempting WiFi reset.")
+            
+            # Use asyncio.to_thread for the blocking subprocess call
+            wifi_reset_success = await asyncio.to_thread(self._reset_wifi_connection)
 
+            if wifi_reset_success:
+                logger.info("WiFi reset seemed successful. Attempting to fetch weather data one more time.")
+                try:
+                    data = await self.__get_weather() # One more try
+                except (httpx.RequestError, ConnectionError) as e_after_reset:
+                    logger.error(f"Fetching weather data failed even after WiFi reset: {e_after_reset}")
+                    logger.info("Proceeding to system reboot due to persistent connection issues after WiFi reset.")
+                    reboot_issued = await asyncio.to_thread(self._reboot_system)
+                    if reboot_issued:
+                        logger.info("Reboot command dispatched. No further data will be queued in this cycle.")
+                        return # Exit fetch_weather_data early
+                    else:
+                        logger.error("System reboot command failed to dispatch. Proceeding with default weather data.")
+                        data = None # Fallback to default data
+                except Exception as e_generic_after_reset: # Catch any other unexpected error
+                    logger.error(f"An unexpected error occurred fetching weather data after WiFi reset: {e_generic_after_reset}")
+                    logger.info("Proceeding to system reboot due to unexpected error after WiFi reset.")
+                    reboot_issued = await asyncio.to_thread(self._reboot_system)
+                    if reboot_issued:
+                        logger.info("Reboot command dispatched. No further data will be queued in this cycle.")
+                        return # Exit fetch_weather_data early
+                    else:
+                        logger.error("System reboot command failed to dispatch. Proceeding with default weather data.")
+                        data = None # Fallback to default data
+            else: # wifi_reset_success is False
+                logger.error("WiFi reset failed.")
+                logger.info("Proceeding to system reboot due to WiFi reset failure.")
+                reboot_issued = await asyncio.to_thread(self._reboot_system)
+                if reboot_issued:
+                    logger.info("Reboot command dispatched. No further data will be queued in this cycle.")
+                    return # Exit fetch_weather_data early
+                else:
+                    logger.error("System reboot command failed to dispatch. Proceeding with default weather data.")
+                    data = None # Fallback to default data
+        except Exception as e_initial_unexpected: # Catch any other unexpected error from initial __get_weather
+            logger.error(f"An unexpected error occurred during initial weather data fetch: {e_initial_unexpected}")
+            data = None # Should already be None, but ensure it
+
+        # This part is reached if:
+        # 1. Initial __get_weather() succeeded.
+        # 2. Reboot command failed to dispatch, and data was set to None.
         if data:
             try:
                 wd = self.bp.parse(data)
-            except ConnectionError as e:
-                logger.error("Data parsing failed. Cannot send good data. Setting error.")
+            except Exception as e_parse: # Broader exception catch for parsing issues
+                logger.error(f"Data parsing failed: {e_parse}. Setting error.")
                 wd = DEFAULT_WEATHER_DATA
         else:
-            logger.error("Retrieving data failed several times. Setting error.")
+            # This 'else' is hit if data is None. This can happen if:
+            # - Initial __get_weather() failed, and all subsequent recovery (WiFi reset, reboot dispatch) also failed.
+            # - An unexpected error occurred in the initial fetch.
+            logger.error("Setting default weather data as a last resort after other recovery attempts (including reboot dispatch failure).")
             wd = DEFAULT_WEATHER_DATA
 
         await self.queue.put(wd)

--- a/weathervane/datasources.py
+++ b/weathervane/datasources.py
@@ -1,8 +1,10 @@
-import logging
 import asyncio
-import httpx # Ensure this is imported for RequestError
+import logging
 import subprocess
+import sys
 import time
+
+import httpx  # Ensure this is imported for RequestError
 
 from weathervane.parser import BuienradarParser
 
@@ -34,78 +36,68 @@ class BuienRadarDataSource:
         self.bp = BuienradarParser(stations=stations, bits=bits)
 
     @staticmethod
-    async def __get_weather():
+    async def __get_weather() -> dict:
         max_retries = 3
         retry_delay_seconds = 10
-        last_exception = None
 
         for attempt in range(max_retries + 1):
             try:
                 async with httpx.AsyncClient() as client:
                     r = await client.get("https://data.buienradar.nl/2.0/feed/json", timeout=5)
-                
+
                 if r.status_code == HTTP_OK:
-                    logger.info(f"Weather data retrieved in {r.elapsed.total_seconds() * 1000:.0f} ms on attempt {attempt + 1}") # Adjusted logging for timedelta
-                    return r.text
+                    logger.info(
+                        f"Weather data retrieved in {r.elapsed.total_seconds() * 1000:.0f} ms on attempt {attempt + 1}")
+                    return r.json()
                 else:
-                    logger.warning(f"Attempt {attempt + 1}/{max_retries + 1}: Got response in {r.elapsed.total_seconds() * 1000:.0f} ms, but unexpected status code {r.status_code}") # Adjusted logging for timedelta
+                    logger.warning(
+                        f"Attempt {attempt + 1}/{max_retries + 1}: "
+                        f"Got response in {r.elapsed.total_seconds() * 1000:.0f} ms, "
+                        f"but unexpected status code {r.status_code}")
                     last_exception = ConnectionError(f"Buienradar: {r.status_code}")
-                    # This ConnectionError will be caught by the broader except block below if it's the last attempt or just be part of the loop
-                    # To ensure it's caught and processed by the retry logic, we raise it here.
                     raise last_exception
 
             except httpx.RequestError as e:
                 logger.warning(f"Attempt {attempt + 1}/{max_retries + 1}: RequestError connecting to Buienradar: {e}")
                 last_exception = e
-            except ConnectionError as e: # Catching the specific ConnectionError from status_code check
-                # The warning for non-OK status is already logged above.
-                # If we want to avoid re-logging or make it less verbose:
-                # logger.debug(f"Attempt {attempt + 1}/{max_retries + 1}: ConnectionError captured: {e}")
-                last_exception = e # Ensure last_exception is updated
+            except ConnectionError as e:
+                last_exception = e  # Ensure last_exception is updated
 
             if attempt < max_retries:
                 logger.info(f"Waiting {retry_delay_seconds} seconds before retrying...")
                 await asyncio.sleep(retry_delay_seconds)
-            elif last_exception: # If it's the last attempt and an exception occurred
+            elif last_exception:  # If it's the last attempt and an exception occurred
                 logger.error(f"All {max_retries + 1} attempts to connect to Buienradar failed.")
                 raise last_exception
-        
-        # Fallback if loop finishes unexpectedly (should ideally be covered by raise last_exception)
-        # This part might be unreachable if last_exception is always raised on failure,
-        # but it's a safeguard as per the provided example.
+
         logger.error("Exited retry loop for Buienradar without success or explicit error (should not happen).")
         raise ConnectionError("Failed to retrieve data from Buienradar after multiple attempts.")
 
     @staticmethod
     def _reboot_system():
         logger.info("Attempting system reboot using 'sudo reboot'...")
-        command = ["sudo", "reboot"]
         try:
-            # Using Popen for reboot as it's a non-returning command usually.
-            subprocess.Popen(command)
             logger.info("Reboot command issued. The system should now restart.")
-            # If Popen succeeds, script may end before this is reached or continue briefly.
-            # Return True to indicate the command was dispatched without Popen throwing an error.
+            subprocess.Popen(["sudo", "reboot"])
             return True
         except FileNotFoundError:
-            logger.error("Reboot command failed: `sudo` or `reboot` not found. Ensure these utilities are installed and in PATH.")
-            return False # Return False indicating command couldn't be dispatched
+            logger.error(
+                "Reboot command failed: `sudo` or `reboot` not found. Ensure these utilities are installed and in PATH.")
+            sys.exit(1)
         except Exception as e:
             logger.error(f"An unexpected error occurred while trying to issue reboot command: {e}")
-            return False # Return False indicating command couldn't be dispatched
+            sys.exit(1)  # Exit the program with an error code
 
     @staticmethod
     def _reset_wifi_connection():
         logger.info("Attempting WiFi reset using 'sudo ifdown wlan0 && sudo ifup wlan0'...")
-        cmd_string = "sudo ifdown wlan0 && sudo ifup wlan0"
-
         try:
-            # Using shell=True for the compound command.
-            result = subprocess.run(cmd_string, shell=True, capture_output=True, text=True, check=False, timeout=60) 
+            cmd_string = "sudo ifdown wlan0 && sudo ifup wlan0"
+            result = subprocess.run(cmd_string, shell=True, capture_output=True, text=True, check=False, timeout=60)
             if result.returncode == 0:
                 logger.info("WiFi reset command executed successfully.")
                 logger.info("Waiting 10 seconds for network to re-establish...")
-                time.sleep(10) 
+                time.sleep(10)
                 return True
             else:
                 logger.error(f"WiFi reset command failed with return code {result.returncode}.")
@@ -115,7 +107,8 @@ class BuienRadarDataSource:
                     logger.error(f"STDERR: {result.stderr.strip()}")
                 return False
         except FileNotFoundError:
-            logger.error("WiFi reset command failed: `sudo`, `ifdown`, or `ifup` not found. Ensure these utilities are installed and in PATH.")
+            logger.error(
+                "WiFi reset command failed: `sudo`, `ifdown`, or `ifup` not found. Ensure these utilities are installed and in PATH.")
             return False
         except subprocess.TimeoutExpired:
             logger.error("WiFi reset command timed out after 60 seconds.")
@@ -130,47 +123,48 @@ class BuienRadarDataSource:
             data = await self.__get_weather()
         except (httpx.RequestError, ConnectionError) as e:
             logger.warning(f"Initial attempts to fetch weather data failed: {e}. Attempting WiFi reset.")
-            
+
             # Use asyncio.to_thread for the blocking subprocess call
             wifi_reset_success = await asyncio.to_thread(self._reset_wifi_connection)
 
             if wifi_reset_success:
                 logger.info("WiFi reset seemed successful. Attempting to fetch weather data one more time.")
                 try:
-                    data = await self.__get_weather() # One more try
+                    data = await self.__get_weather()  # One more try
                 except (httpx.RequestError, ConnectionError) as e_after_reset:
                     logger.error(f"Fetching weather data failed even after WiFi reset: {e_after_reset}")
                     logger.info("Proceeding to system reboot due to persistent connection issues after WiFi reset.")
                     reboot_issued = await asyncio.to_thread(self._reboot_system)
                     if reboot_issued:
                         logger.info("Reboot command dispatched. No further data will be queued in this cycle.")
-                        return # Exit fetch_weather_data early
+                        return  # Exit fetch_weather_data early
                     else:
                         logger.error("System reboot command failed to dispatch. Proceeding with default weather data.")
-                        data = None # Fallback to default data
-                except Exception as e_generic_after_reset: # Catch any other unexpected error
-                    logger.error(f"An unexpected error occurred fetching weather data after WiFi reset: {e_generic_after_reset}")
+                        data = None  # Fallback to default data
+                except Exception as e_generic_after_reset:  # Catch any other unexpected error
+                    logger.error(
+                        f"An unexpected error occurred fetching weather data after WiFi reset: {e_generic_after_reset}")
                     logger.info("Proceeding to system reboot due to unexpected error after WiFi reset.")
                     reboot_issued = await asyncio.to_thread(self._reboot_system)
                     if reboot_issued:
                         logger.info("Reboot command dispatched. No further data will be queued in this cycle.")
-                        return # Exit fetch_weather_data early
+                        return  # Exit fetch_weather_data early
                     else:
                         logger.error("System reboot command failed to dispatch. Proceeding with default weather data.")
-                        data = None # Fallback to default data
-            else: # wifi_reset_success is False
+                        data = None  # Fallback to default data
+            else:  # wifi_reset_success is False
                 logger.error("WiFi reset failed.")
                 logger.info("Proceeding to system reboot due to WiFi reset failure.")
                 reboot_issued = await asyncio.to_thread(self._reboot_system)
                 if reboot_issued:
                     logger.info("Reboot command dispatched. No further data will be queued in this cycle.")
-                    return # Exit fetch_weather_data early
+                    return  # Exit fetch_weather_data early
                 else:
                     logger.error("System reboot command failed to dispatch. Proceeding with default weather data.")
-                    data = None # Fallback to default data
-        except Exception as e_initial_unexpected: # Catch any other unexpected error from initial __get_weather
+                    data = None  # Fallback to default data
+        except Exception as e_initial_unexpected:  # Catch any other unexpected error from initial __get_weather
             logger.error(f"An unexpected error occurred during initial weather data fetch: {e_initial_unexpected}")
-            data = None # Should already be None, but ensure it
+            data = None  # Should already be None, but ensure it
 
         # This part is reached if:
         # 1. Initial __get_weather() succeeded.
@@ -178,14 +172,15 @@ class BuienRadarDataSource:
         if data:
             try:
                 wd = self.bp.parse(data)
-            except Exception as e_parse: # Broader exception catch for parsing issues
+            except Exception as e_parse:  # Broader exception catch for parsing issues
                 logger.error(f"Data parsing failed: {e_parse}. Setting error.")
                 wd = DEFAULT_WEATHER_DATA
         else:
             # This 'else' is hit if data is None. This can happen if:
             # - Initial __get_weather() failed, and all subsequent recovery (WiFi reset, reboot dispatch) also failed.
             # - An unexpected error occurred in the initial fetch.
-            logger.error("Setting default weather data as a last resort after other recovery attempts (including reboot dispatch failure).")
+            logger.error(
+                "Setting default weather data as a last resort after other recovery attempts (including reboot dispatch failure).")
             wd = DEFAULT_WEATHER_DATA
 
         await self.queue.put(wd)

--- a/weathervane/parser.py
+++ b/weathervane/parser.py
@@ -127,10 +127,9 @@ class BuienradarParser(object):
         self.stations = stations
         self.bits = bits
 
-    def parse(self, data: str) -> dict:
-        raw_weather_data = json.loads(data)
+    def parse(self, data: dict) -> dict:
         raw_stations_weather_data = self._to_dict(
-            raw_weather_data["actual"]["stationmeasurements"]
+            data["actual"]["stationmeasurements"]
         )
         raw_primary_station_data = self.merge(
             raw_stations_weather_data, self.stations, self.bits


### PR DESCRIPTION
Raspberry Pi units with unstable WiFi connections may drop connectivity, causing stale data to display. When the script fails to retrieve fresh data, it first attempts to reset WiFi, then reboots the Pi if that fails. Combined with the Google connectivity check that prevents the script from proceeding without internet access, the display will show "waiting for raspberry pi" as the default message during connection issues.