### PR TITLE
Fix read-only filesystem logging error

### DIFF
--- a/main.py
+++ b/main.py
@@ -17,13 +17,8 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 formatter = logging.Formatter("%(asctime)s:%(levelname)s:%(module)s:%(message)s")
 
-# Configure logging to both file and stdout
-# File logging for detailed application logs (systemd handles rotation)
-file_handler = logging.FileHandler("/home/weathervane/weathervane.log")
-file_handler.setFormatter(formatter)
-logger.addHandler(file_handler)
-
-# Stream logging for systemd journal
+# Configure logging for systemd journal
+# systemd captures stdout/stderr and handles log rotation automatically
 stream_handler = logging.StreamHandler()
 stream_handler.setFormatter(formatter)
 logger.addHandler(stream_handler)


### PR DESCRIPTION
## Summary
• Removes file logging to fix OSError: [Errno 30] Read-only file system
• Resolves weathervane service startup failure on read-only filesystems

## Root Cause
The FileHandler was attempting to write to `/home/weathervane/weathervane.log`, which fails when the filesystem is mounted read-only (common on Raspberry Pi systems for reliability).

## Solution
• Remove FileHandler completely - systemd already captures stdout/stderr in journal
• Keep only StreamHandler for console output that systemd automatically manages
• All logs remain accessible via `journalctl -u weathervane.service`

## Test plan
- [ ] Verify service starts successfully on read-only filesystem
- [ ] Confirm logs are accessible via journalctl
- [ ] Test on standard read-write filesystem (should work the same)

🤖 Generated with [Claude Code](https://claude.ai/code)