### PR TITLE
Clean up Pi 5 workarounds and simplify GPIO initialization

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -250,10 +250,6 @@ execute_cmd "find $WEATHERVANE_HOME/weathervane -name '*.ini' -exec chmod 640 {}
 execute_cmd "chmod 755 $WEATHERVANE_HOME" "setting home directory permissions"
 execute_cmd "chmod 755 $WEATHERVANE_HOME/weathervane" "setting weathervane directory permissions"
 
-# Fix for Pi 5 lgpio notification pipes - ensure weathervane user can write to working directory
-execute_cmd "chmod u+w $WEATHERVANE_HOME/weathervane" "ensuring write permissions for lgpio notification pipes"
-# Clean up any stale lgpio notification pipes from previous runs
-execute_cmd "rm -f $WEATHERVANE_HOME/weathervane/.lgd-nfy*" "cleaning stale lgpio pipes"
 
 if [ "$VERBOSE" = true ]; then
     echo "  Set secure permissions: 750 for directories, 640 for Python/config files"
@@ -462,6 +458,8 @@ echo "=== END SUMMARY ==="
 echo -e "\n${GREEN}✅ Installation completed successfully!${NC}"
 
 echo -e "${BLUE}Service Status:${NC}"
+# Wait a moment for service to fully initialize before checking status
+sleep 3
 systemctl status weathervane.service --no-pager -l
 
 

--- a/weathervane.service
+++ b/weathervane.service
@@ -9,8 +9,6 @@ Group=weathervane
 WorkingDirectory=/home/weathervane/weathervane
 # Force gpiozero to use lgpio for Raspberry Pi 5 compatibility
 Environment="GPIOZERO_PIN_FACTORY=lgpio"
-# Clean up stale lgpio notification pipes before starting
-ExecStartPre=/bin/rm -f /home/weathervane/weathervane/.lgd-nfy*
 ExecStart=/home/weathervane/venv/bin/python /home/weathervane/weathervane/main.py -c /home/weathervane/weathervane/config.ini
 StandardOutput=journal
 StandardError=journal

--- a/weathervane.service
+++ b/weathervane.service
@@ -7,6 +7,8 @@ Type=simple
 User=weathervane
 Group=weathervane
 WorkingDirectory=/home/weathervane/weathervane
+# Force gpiozero to use lgpio for Raspberry Pi 5 compatibility
+Environment="GPIOZERO_PIN_FACTORY=lgpio"
 # Clean up stale lgpio notification pipes before starting
 ExecStartPre=/bin/rm -f /home/weathervane/weathervane/.lgd-nfy*
 ExecStart=/home/weathervane/venv/bin/python /home/weathervane/weathervane/main.py -c /home/weathervane/weathervane/config.ini

--- a/weathervane.service
+++ b/weathervane.service
@@ -36,7 +36,8 @@ RestrictNamespaces=yes
 # Allow access to GPIO and SPI
 SupplementaryGroups=gpio spi
 DeviceAllow=/dev/gpiomem rw
-DeviceAllow=/dev/gpiochip* rw
+DeviceAllow=/dev/gpiochip0 rw
+DeviceAllow=/dev/gpiochip4 rw
 DeviceAllow=/dev/spidev0.0 rw
 DeviceAllow=/dev/spidev0.1 rw
 

--- a/weathervane/weathervaneinterface.py
+++ b/weathervane/weathervaneinterface.py
@@ -5,7 +5,6 @@ from random import randint
 from typing import List
 
 import gpiozero
-from gpiozero import Device
 
 from weathervane.gpio import GPIO
 

--- a/weathervane/weathervaneinterface.py
+++ b/weathervane/weathervaneinterface.py
@@ -148,31 +148,9 @@ class Display(object):
         end_time = kwargs.get("end-time", "22:00")
         self.end_at_minutes = Display.convert_to_minutes(end_time)
         
-        # Initialize GPIO with appropriate pin factory
+        # Initialize GPIO LED
         pin = kwargs.get("pin", 4)
-        if Device.pin_factory is None:
-            # Try LGPIOFactory first for Pi 5 compatibility
-            try:
-                from gpiozero.pins.lgpio import LGPIOFactory
-                Device.pin_factory = LGPIOFactory(chip=0)
-                logger.info("Using LGPIOFactory for GPIO operations (Pi 5 compatible)")
-            except Exception as e:
-                logger.warning(f"Failed to initialize LGPIOFactory: {e}")
-                # Try native factory next
-                try:
-                    from gpiozero.pins.native import NativeFactory
-                    Device.pin_factory = NativeFactory()
-                    logger.info("Using NativeFactory for GPIO operations")
-                except Exception as e2:
-                    logger.warning(f"Failed to initialize NativeFactory: {e2}")
-                    # Let gpiozero choose the default factory
-                    logger.info("Using default pin factory")
-        
-        try:
-            self.display = gpiozero.LED(pin)
-        except Exception as e:
-            logger.error(f"Failed to initialize LED on pin {pin}: {e}")
-            raise
+        self.display = gpiozero.LED(pin)
 
     @staticmethod
     def convert_to_minutes(time_text):


### PR DESCRIPTION
## Summary
- Removes unnecessary workarounds now that the proper Pi 5 fix is in place
- Simplifies GPIO initialization code
- Adds delay for service initialization in install script

## Changes
- **Remove unnecessary workarounds:**
  - lgpio notification pipe cleanup from install script
  - ExecStartPre pipe cleanup from service file
  - Complex GPIO factory fallback logic from weathervaneinterface.py

- **Keep the working solution:**
  - `GPIOZERO_PIN_FACTORY=lgpio` environment variable
  - Explicit DeviceAllow entries for gpiochip devices

- **Improve user experience:**
  - Add 3 second delay before showing service status to allow initialization

## Context
After extensive testing, we found that the environment variable + DeviceAllow fixes are sufficient for Pi 5 compatibility. The other workarounds were attempts that are no longer needed, so this PR cleans them up for a simpler, cleaner codebase.

## Test plan
- [x] Verified service starts on Raspberry Pi 5
- [ ] Test on older Pi models (Pi 3, Pi 4, Zero, etc.)
- [ ] Verify GPIO LED control works on all models

🤖 Generated with [Claude Code](https://claude.ai/code)